### PR TITLE
Ensure version 3.7 works

### DIFF
--- a/tasks/Debian/install.yml
+++ b/tasks/Debian/install.yml
@@ -15,10 +15,17 @@
   apt_key:
     url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
 
-- name: download rabbitmq package
+- name: download rabbitmq package from releases (for version < 3.7) 
   get_url:
     url: "https://www.rabbitmq.com/releases/rabbitmq-server/v{{ rabbitmq_version.split('-')[0] }}/rabbitmq-server_{{ rabbitmq_version }}{% if rabbitmq_version | version_compare('3.6.6', '>=') %}{% endif %}_all.deb"
     dest: "/usr/src/rabbitmq-server-{{ rabbitmq_version }}.deb"
+  when: rabbitmq_version is version_compare('3.7', '<')
+
+- name: download rabbitmq package from GitHub (for version > 3.7) 
+  get_url:
+    url: "https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitmq_version.split('-')[0] }}/rabbitmq-server_{{ rabbitmq_version }}_all.deb"
+    dest: "/usr/src/rabbitmq-server-{{ rabbitmq_version }}.deb"
+  when: rabbitmq_version is version_compare('3.7', '>=')
 
 - name: install rabbitmq
   apt:

--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -11,7 +11,7 @@
   service:
     name: rabbitmq-server
     enabled: True
-    state: started
+    state: restarted
 
 - include: vhosts.yml
 


### PR DESCRIPTION
Since OTP 21 is now available from Erlang Solutions, it is installed by default. This requires RabbitMQ 3.7.7 and above.

As of version 3.7, the releases are stored in a different location, so the task has been modified to fetch the release from GitHub.

There is no way to customise the OTP version, so perhaps it is worth requiring a version of 3.7.7 or above and deleting the 3.6 version of the task?

It is also required to restart the rabbitmq server before running rabbitmqctl when using a cluster as the cookie does not match otherwise.